### PR TITLE
Use K Binary Release for demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /solidity/*/*.evm
 /*.deb
+/evm-semantics
+/k
+/k.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+/compiled.zip
+/coverage.json
 /evm-semantics
 /k
 /k.tar.gz
 /openzeppelin-contracts
+/report.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-/solidity/*/*.evm
-/*.deb
 /evm-semantics
 /k
 /k.tar.gz
+/openzeppelin-contracts

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-.PHONY: solc-compile
-
-solidity_code := $(wildcard solidity/*/*.sol)
-
-solidity/%.sol.evm: solidity/%.sol
-	solc --bin $< | tail -n1 > $@
-
-solc-compile: $(solidity_code:=.evm)

--- a/firefly-demo.sh
+++ b/firefly-demo.sh
@@ -15,6 +15,7 @@ export K_RELEASE=$(pwd)/k
 # install evm-semantics
 git clone https://github.com/kframework/evm-semantics.git
 cd evm-semantics
+git submodule update --init --recursive -- deps/plugin
 make build-web3
 cd ..
 

--- a/firefly-demo.sh
+++ b/firefly-demo.sh
@@ -4,15 +4,17 @@ set -euo pipefail
 
 export FIREFLY_TOKEN="U052ZEQvZjVpZ0lQbjd1R1NlNFJpZGNTbVppbVFFSng4RWhOclpaTVk2RT0="
 
+# Eventually this is how we'll do it, currently unused.
 # contact Web API and download runner
-curl https://sandbox.fireflyblockchain.com/script?firefly_token="$FIREFLY_TOKEN" | sh
+# curl https://sandbox.fireflyblockchain.com/script?firefly_token="$FIREFLY_TOKEN" | sh
+
+curl --location --output k.tar.gz 'https://github.com/kframework/k/releases/download/v5.0.0-9985955/k-nightly.tar.gz'
+tar --verbose --extract --file k.tar.gz
+export K_RELEASE=$(pwd)/k
 
 # install evm-semantics
-mkdir build
-cd build
 git clone https://github.com/kframework/evm-semantics.git
 cd evm-semantics
-make deps
 make build-web3
 cd ..
 

--- a/firefly-run.sh
+++ b/firefly-run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xeuo pipefail
+set -euo pipefail
 
 export FIREFLY_TOKEN="U052ZEQvZjVpZ0lQbjd1R1NlNFJpZGNTbVppbVFFSng4RWhOclpaTVk2RT0="
 

--- a/firefly-run.sh
+++ b/firefly-run.sh
@@ -37,6 +37,7 @@ cd ..
 # close kevm (optional)
 cd evm-semantics
 ./kevm web3-send "$PORT" 'firefly_shutdown'
+cd ..
 
 # post the reports
 curl -X POST -F access-token="$FIREFLY_TOKEN"                                        \

--- a/firefly-run.sh
+++ b/firefly-run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -xeuo pipefail
 
 export FIREFLY_TOKEN="U052ZEQvZjVpZ0lQbjd1R1NlNFJpZGNTbVppbVFFSng4RWhOclpaTVk2RT0="
 

--- a/firefly-run.sh
+++ b/firefly-run.sh
@@ -37,11 +37,6 @@ cd ..
 # close kevm (optional)
 cd evm-semantics
 ./kevm web3-send "$PORT" 'firefly_shutdown'
-echo
-timeout 8 tail --pid="$kevm_client_pid" -f /dev/null || true
-pkill -P "$kevm_client_pid" kevm-client              || true
-timeout 8 tail --pid="$kevm_client_pid" -f /dev/null || true
-cd ..
 
 # post the reports
 curl -X POST -F access-token="$FIREFLY_TOKEN"                                        \

--- a/firefly-setup.sh
+++ b/firefly-setup.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # export FIREFLY_TOKEN="U052ZEQvZjVpZ0lQbjd1R1NlNFJpZGNTbVppbVFFSng4RWhOclpaTVk2RT0="
 # curl https://sandbox.fireflyblockchain.com/script?firefly_token="$FIREFLY_TOKEN" | sh
 
-curl --location --output k.tar.gz 'https://github.com/kframework/k/releases/download/v5.0.0-9985955/k-nightly.tar.gz'
+curl --location --output k.tar.gz 'https://github.com/kframework/k/releases/download/v5.0.0-280480e/k-nightly.tar.gz'
 tar --verbose --extract --file k.tar.gz
 export K_RELEASE=$(pwd)/k
 

--- a/firefly-setup.sh
+++ b/firefly-setup.sh
@@ -14,5 +14,6 @@ export K_RELEASE=$(pwd)/k
 # install evm-semantics
 git clone https://github.com/kframework/evm-semantics.git
 cd evm-semantics
+git checkout 22569ff809d73903894db5a7b0dad0eb3bc82a73
 git submodule update --init --recursive -- deps/plugin
 make build-web3

--- a/firefly-setup.sh
+++ b/firefly-setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Eventually this is how we'll do it, currently unused.
+# contact Web API and download runner
+# export FIREFLY_TOKEN="U052ZEQvZjVpZ0lQbjd1R1NlNFJpZGNTbVppbVFFSng4RWhOclpaTVk2RT0="
+# curl https://sandbox.fireflyblockchain.com/script?firefly_token="$FIREFLY_TOKEN" | sh
+
+curl --location --output k.tar.gz 'https://github.com/kframework/k/releases/download/v5.0.0-9985955/k-nightly.tar.gz'
+tar --verbose --extract --file k.tar.gz
+export K_RELEASE=$(pwd)/k
+
+# install evm-semantics
+git clone https://github.com/kframework/evm-semantics.git
+cd evm-semantics
+git submodule update --init --recursive -- deps/plugin
+make build-web3

--- a/instructions.md
+++ b/instructions.md
@@ -92,7 +92,7 @@ apt-get install --yes nodejs
 
 As part of your CI job, make sure to clone and build Firefly:
 
-```
+```sh
 curl --location --output k.tar.gz 'https://github.com/kframework/k/releases/download/v5.0.0-9985955/k-nightly.tar.gz'
 tar --verbose --extract --file k.tar.gz
 export K_RELEASE=$(pwd)/k
@@ -109,13 +109,14 @@ cd ..
 Zip up your compiled Solidity contracts.
 They exist under the `build` directory in this example (where `truffle compile` places them).
 
-```
+```sh
+truffle compile
 zip compiled.zip -r build/
 ```
 
 Launch the Firefly client (we use port 8545 in this example):
 
-```
+```sh
 cd evm-semantics
 ./kevm web3-ganache 8545 --shutdownable &
 cd ..
@@ -123,13 +124,13 @@ cd ..
 
 Run the test suite that will talk to the Firefly client (ie. Truffle), saving the output:
 
-```
+```sh
 truffle test &> results.txt
 ```
 
 Retrieve the coverage data from Firefly and then close the client:
 
-```
+```sh
 cd evm-semantics
 ./kevm web3-send 8545 firefly_getCoverageData &> ../coverage.json
 ./kevm web3-send 8545 firefly_shutdown
@@ -138,7 +139,7 @@ cd ..
 
 Upload gathered data to the Firefly server for post-processing:
 
-```
+```sh
 curl -X POST -F access-token="<YOUR_ACCESS_TOKEN>"                                   \
              -F 'status=pass'                                                        \
              -F 'file=@report.txt'                                                   \

--- a/instructions.md
+++ b/instructions.md
@@ -99,6 +99,7 @@ export K_RELEASE=$(pwd)/k
 
 git clone https://github.com/kframework/evm-semantics.git
 cd evm-semantics
+git submodule update --init --recursive -- deps/plugin
 make build-web3
 cd ..
 ```

--- a/instructions.md
+++ b/instructions.md
@@ -84,8 +84,8 @@ sudo apt-get install --yes solc
 Install `nodejs` (>= 10.0.0):
 
 ```sh
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
-apt-get install --yes nodejs
+curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
+sudo apt-get install --yes nodejs
 ```
 
 ## Build Firefly

--- a/instructions.md
+++ b/instructions.md
@@ -1,27 +1,30 @@
 ## Authorize Github
 
- - Go to sandbox.fireflyblockchain.com
- - At the top right, click on "login"
- - At the Github OAuth screen, click on the "Authorize rv-jenkins" button
+-   Go to sandbox.fireflyblockchain.com
+-   At the top right, click on "login"
+-   At the Github OAuth screen, click on the "Authorize rv-jenkins" button
 
-![](https://raw.githubusercontent.com/runtimeverification/firefly-demo/guy_doc/img/1authorize.png)
+![](img/1authorize.png)
 
 ## Set up an access token
 
- - After being redirected, go to the "Products" drop-down in the top right and click on "test runner"
+-   After being redirected, go to the "Products" drop-down in the top right and click on "test runner"
 
-![](https://raw.githubusercontent.com/runtimeverification/firefly-demo/guy_doc/img/2testrunner.png)
- - Click on the "install now" button at the new page
- - Type in a name for your new token and click on "create"
+![](img/2testrunner.png)
 
-![](https://raw.githubusercontent.com/runtimeverification/firefly-demo/guy_doc/img/3createtoken.png)
- - Save the token for later
+-   Click on the "install now" button at the new page
+-   Type in a name for your new token and click on "create"
+
+![](img/3createtoken.png)
+
+-   Save the token for later
 
 ## Set up CI
 
 In your CI script, have a stage that does the following:
 
 Install the Firefly client. The following dependencies must be installed for Ubuntu:
+
 ```
 autoconf
 bison
@@ -67,11 +70,13 @@ cd ..
 ```
 
 Zip up your compiled Solidity contracts (They exist under the `build` directory in this example)
+
 ```
 zip compiled.zip -r build/
 ```
 
 Launch the Firefly client (we use port 8545 in this example)
+
 ```
 cd evm-semantics
 ./kevm web3-ganache 8545 --shutdownable &
@@ -79,11 +84,13 @@ cd ..
 ```
 
 Run the test suite that will talk to the Firefly client (ie. Truffle). Save the output.
+
 ```
 truffle test &> results.txt
 ```
 
 Retrieve the coverage data from Firefly and then close the client.
+
 ```
 cd evm-semantics
 ./kevm web3-send 8545 firefly_getCoverageData &> ../coverage.json
@@ -92,13 +99,15 @@ cd ..
 ```
 
 Send the gathered data to the Firefly server
+
 ```
 curl -X POST -F access-token="<YOUR_ACCESS_TOKEN>" -F 'status=pass' -F 'file=@report.txt' -F 'file2=@coverage.json' -F 'file3=@compiled.zip' https://sandbox.fireflyblockchain.com/report
 ```
 
 ## View the report
- - Go back to sandbox.fireflyblockchain.com
- - In the upper right corner click on "Dashboard"
- - You will be shown a list of reports that have come back from CI. You can click on "Coverage" to view the coverage report
 
-![](https://raw.githubusercontent.com/runtimeverification/firefly-demo/guy_doc/img/4coverage.png)
+-   Go back to sandbox.fireflyblockchain.com
+-   In the upper right corner click on "Dashboard"
+-   You will be shown a list of reports that have come back from CI. You can click on "Coverage" to view the coverage report
+
+![](img/4coverage.png)

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -53,6 +53,4 @@ RUN    add-apt-repository ppa:ethereum/ethereum \
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install --yes nodejs
 
-RUN wget -qO- https://get.haskellstack.org/ | bash -
-
 USER user:user

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -35,7 +35,6 @@ pipeline {
           options { timeout(time: 60, unit: 'MINUTES') }
           steps {
             sh '''
-              sudo apt-get update && sudo apt-get upgrade --yes
               ./firefly-demo.sh
             '''
           }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -17,8 +17,6 @@ pipeline {
       when { changeRequest() }
       stages {
         stage('Build Firefly') {
-          agent { dockerfile { dir "jenkins" } }
-          when { changeRequest() }
           options { timeout(time: 5, unit: 'MINUTES') }
           steps {
             sh '''

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
       when { changeRequest() }
       stages {
         stage('Build Firefly') {
-          options { timeout(time: 5, unit: 'MINUTES') }
+          options { timeout(time: 10, unit: 'MINUTES') }
           steps {
             sh '''
               ./firefly-setup.sh
@@ -25,7 +25,7 @@ pipeline {
           }
         }
         stage('Run Firefly') {
-          options { timeout(time: 5, unit: 'MINUTES') }
+          options { timeout(time: 10, unit: 'MINUTES') }
           steps {
             sh '''
               ./firefly-run.sh

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -12,14 +12,28 @@ pipeline {
         }
       }
     }
-    stage('Run Firefly Demo') {
+    stage('Build and Test') {
       agent { dockerfile { dir "jenkins" } }
       when { changeRequest() }
-      options { timeout(time: 60, unit: 'MINUTES') }
-      steps {
-        sh '''
-          ./firefly-demo.sh
-        '''
+      stages {
+        stage('Build Firefly') {
+          agent { dockerfile { dir "jenkins" } }
+          when { changeRequest() }
+          options { timeout(time: 5, unit: 'MINUTES') }
+          steps {
+            sh '''
+              ./firefly-setup.sh
+            '''
+          }
+        }
+        stage('Run Firefly') {
+          options { timeout(time: 5, unit: 'MINUTES') }
+          steps {
+            sh '''
+              ./firefly-run.sh
+            '''
+          }
+        }
       }
     }
   }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -5,40 +5,21 @@ pipeline {
   }
   stages {
     stage("Init title") {
-      when {
-        changeRequest()
-        beforeAgent true
-      }
+      when { changeRequest() }
       steps {
         script {
           currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}"
         }
       }
     }
-    stage('Build and Test') {
-      agent {
-        dockerfile { dir "jenkins" }
-      }
-      when {
-        changeRequest()
-        beforeAgent true
-      }
-      stages {
-        stage('Build Solidity') {
-          steps {
-            sh '''
-              make solc-compile
-            '''
-          }
-        }
-        stage('Run Firefly Demo') {
-          options { timeout(time: 60, unit: 'MINUTES') }
-          steps {
-            sh '''
-              ./firefly-demo.sh
-            '''
-          }
-        }
+    stage('Run Firefly Demo') {
+      agent { dockerfile { dir "jenkins" } }
+      when { changeRequest() }
+      options { timeout(time: 60, unit: 'MINUTES') }
+      steps {
+        sh '''
+          ./firefly-demo.sh
+        '''
       }
     }
   }

--- a/solidity/hello-world/hello-world.sol
+++ b/solidity/hello-world/hello-world.sol
@@ -1,5 +1,0 @@
-contract helloWorld {
- function meaning_of_life() public pure returns (uint) {
-   return 42;
- }
-}


### PR DESCRIPTION
-    Separate firefly-demo.sh into firefly-setup.sh and firefly-demo.sh.
-    Clean up gitignore and remove a bunch of unused parts of the repo.
-    Uses binary release of K for building KEVM, instead of from source.