### PR TITLE
Add example of contract inheritance to firefly-demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 ARG DOCKERHUB_TAG
 FROM runtimeverificationinc/runtimeverification-firefly:${DOCKERHUB_TAG}
 
-USER root:root
-
 RUN    apt-get update                          \
     && apt-get upgrade --yes                   \
     && apt-get install --yes                   \
@@ -14,12 +12,15 @@ RUN    curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && apt-get upgrade --yes                                   \
     && apt-get install --yes nodejs
 
-RUN    add-apt-repository ppa:ethereum/ethereum \
-    && apt-get update                           \
-    && apt-get upgrade --yes                    \
-    && apt-get install --yes solc
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER user:user
 WORKDIR /home/user
+
+ENV NPM_PACKAGES=/home/user/.npm-packages
+ENV PATH=$NPM_PACKAGES/bin:$PATH
+RUN npm config set prefix $NPM_PACKAGES
 
 ENV LC_ALL=C.UTF-8

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
         sh '''
           npm install
           firefly compile
-          firefly launch   -p 8145 --quiet &
+          firefly launch   -p 8145 --quiet --shutdownable --respond-to-notifications &
           sleep 2
           firefly test
           firefly coverage -p 8145

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,5 +26,16 @@ pipeline {
         '''
       }
     }
+    stage('Update Firefly Submodule') {
+      when { branch 'master' }
+      steps {
+        build job: 'rv-devops/master', propagate: false, wait: false                                     \
+            , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                     \
+                          , string(name: 'PR_REVIEWER', value: 'ehildenb')                               \
+                          , string(name: 'UPDATE_DEPS_REPOSITORY', value: 'runtimeverification/firefly') \
+                          , string(name: 'UPDATE_DEPS_SUBMODULE_DIR', value: 'tests/demos/firefly-demo') \
+                          ]
+      }
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,8 @@ pipeline {
         sh '''
           npm install
           firefly compile
-          firefly launch   -p 8145
+          firefly launch   -p 8145 &
+          sleep 2
           firefly test
           firefly coverage -p 8145
           firefly close    -p 8145

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
         sh '''
           npm install
           firefly compile
-          firefly launch   -p 8145 &
+          firefly launch   -p 8145 --quiet &
           sleep 2
           firefly test
           firefly coverage -p 8145

--- a/contracts/ERC20EXT.sol
+++ b/contracts/ERC20EXT.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.5.16;
+import "./ERC20.sol";
+
+contract ERC20EXT is ERC20 {
+    constructor(
+        string memory name,
+        string memory symbol,
+        address initAccount,
+        uint256 initSupply
+    ) public ERC20(name, symbol, initAccount, initSupply) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function mint(address account, uint256 amount) public returns (bool) {
+        _mint(account, amount);
+        return true;
+    }
+
+    function burn(address account, uint256 amount) public returns (bool) {
+        _burn(account, amount);
+        return true;
+    }
+}

--- a/test/TestERC20EXT.sol
+++ b/test/TestERC20EXT.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.5.8;
+import "truffle/Assert.sol";
+import "../contracts/ERC20.sol";
+import "../contracts/ERC20EXT.sol";
+contract TestERC20EXT {
+  function testmint() public {
+    address acct1 = address(0x01);
+    ERC20EXT erc20ext = new ERC20EXT("Gold", "GLD", acct1, 1000);
+    Assert.equal(erc20ext.balanceOf(acct1), 1000, "initial mint works");
+    erc20ext.mint(acct1, 100);
+    Assert.equal(erc20ext.balanceOf(acct1), 1100, "mint increases amount");
+  }
+}


### PR DESCRIPTION
Fixes: runtimeverification/firefly#938

Added `contracts/ERC20EXT.sol` and `test/TestERC20EXT.sol`. [Here](https://sandbox.fireflyblockchain.com/app/report.html?reportId=95680438-36ac-421e-8bde-890c4f243c38) is a demo of the result in the firefly dashboard frontend.