### PR TITLE
Add ownerOnly modifier

### DIFF
--- a/contracts/ERC20EXT.sol
+++ b/contracts/ERC20EXT.sol
@@ -1,7 +1,8 @@
 pragma solidity ^0.5.16;
 import "./ERC20.sol";
+import "./Owned.sol";
 
-contract ERC20EXT is ERC20 {
+contract ERC20EXT is ERC20, Owned {
     constructor(
         string memory name,
         string memory symbol,
@@ -19,5 +20,9 @@ contract ERC20EXT is ERC20 {
     function burn(address account, uint256 amount) public returns (bool) {
         _burn(account, amount);
         return true;
+    }
+
+    function displayName() public view onlyOwner returns (string memory) {
+        return name();
     }
 }

--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.16;
+
+contract Owned {
+    constructor() public {
+        owner = msg.sender;
+    }
+
+    address owner;
+
+    modifier onlyOwner {
+        require(msg.sender == owner, "Only owner can call this function.");
+        _;
+    }
+}

--- a/test/TestERC20EXT.js
+++ b/test/TestERC20EXT.js
@@ -13,4 +13,9 @@ contract('ERC20EXT', accounts => {
         assert.equal(await erc20ext.balanceOf(accounts[1]), 10);
     });
 
+    it("Call owner only functions", async () => {
+        const erc20ext = await ERC20EXT.new("Gold", "GLD", accounts[0], 1000);
+        assert.equal(await erc20ext.displayName(), "Gold");
+    });
+
 });


### PR DESCRIPTION
This pull request is related to runtimeverification/firefly#1036. Here the "Owned" contract is added for simulating the owner-only function, and we might need to write more sophisticated test cases.